### PR TITLE
Added collect step snippet data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+
+before_install:
+  - gem install bundler
+
 rvm:
 - ruby-head
 - 2.2.0

--- a/cucumber-formatters.gemspec
+++ b/cucumber-formatters.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.summary      = 'A helpful bunch of formatters'
   spec.description  = 'A collection of cucumber formatters'
   spec.homepage     = 'http://benslaughter.github.io/cucumber-formatters/'
-  spec.version      = '1.0.0'
+  spec.version      = '1.1.0'
   spec.version      = "#{spec.version}-#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
   spec.date         = '2015-11-09'
   spec.license      = 'MIT'

--- a/lib/cucumber/formatter/failures.rb
+++ b/lib/cucumber/formatter/failures.rb
@@ -13,14 +13,22 @@ module Cucumber
     #       Full stacktrace
     #
     class Failures
-      include Cucumber::Formatter::Io
-      include Cucumber::Formatter::Console
+      include Console
+      include Io
+      attr_writer :indent
       attr_reader :runtime
 
       def initialize(runtime, path_or_io, options)
         @runtime = runtime
-        @io      = ensure_io(path_or_io)
+        @io = ensure_io(path_or_io)
         @options = options
+        @exceptions = []
+        @indent = 0
+        @prefixes = options[:prefixes] || {}
+        @delayed_messages = []
+        @previous_step_keyword = nil
+        @snippets_input = []
+        @output = []
       end
 
       def before_features(_features)
@@ -78,6 +86,10 @@ module Cucumber
         return unless table_row.exception
         @table_row = "    Row: #{table_row.name}"
         exception(table_row.exception, table_row.status, 6)
+      end
+
+      def after_test_step(test_step, result)
+        collect_snippet_data(test_step, result)
       end
 
       private

--- a/lib/cucumber/formatter/simpledoc.rb
+++ b/lib/cucumber/formatter/simpledoc.rb
@@ -54,7 +54,7 @@ module Cucumber
 
       def scenario_name(keyword, name, file_colon_line, _source_indent)
         @scenario = "  #{keyword}: #{name}"
-        @io.puts "#{@scenario}".ljust(75) + yellow(" #{file_colon_line}")
+        @io.puts @scenario.to_s.ljust(75) + yellow(" #{file_colon_line}")
         @io.flush
       end
 


### PR DESCRIPTION
Adding the collect_snippet_data method to ensure that the formatter collects the snippet data from the steps so that when steps are undefined they can be presented in the summary.