### PR TITLE
Added rerun dump formatter

### DIFF
--- a/lib/cucumber/formatter/rerun_dump.rb
+++ b/lib/cucumber/formatter/rerun_dump.rb
@@ -1,0 +1,36 @@
+require 'cucumber/formatter/io'
+
+module Cucumber
+  module Formatter
+    # Works like rerun but just outputs file location and line number
+    # Each new test is output to a new line
+    class RerunDump
+      include Cucumber::Formatter::Io
+
+      def initialize(_runtime, path_or_io, options)
+        @io = ensure_io(path_or_io)
+        @results = []
+        @options = options
+      end
+
+      def after_test_case(test_case, _result)
+        @results << [test_case.location.file, test_case.location.line]
+      end
+
+      def done
+        return if @results.empty?
+        @io.print file_failures.join("\n")
+      end
+
+      [:before_test_case, :before_test_step, :after_test_step].each do |method|
+        define_method(method) { |*| }
+      end
+
+      private
+
+      def file_failures
+        @results.map { |file, lines| [file, lines].join(':') }
+      end
+    end
+  end
+end

--- a/lib/cucumber/formatters.rb
+++ b/lib/cucumber/formatters.rb
@@ -1,4 +1,5 @@
 require 'cucumber/formatter/failures'
+require 'cucumber/formatter/rerun_dump'
 require 'cucumber/formatter/simplecsv'
 require 'cucumber/formatter/simpledoc'
 require 'cucumber/cli/main'
@@ -8,6 +9,11 @@ require 'cucumber/cli/main'
 Cucumber::Cli::Options::BUILTIN_FORMATS['failures'] = [
   'Cucumber::Formatter::Failures',
   'Outputs scenario information and stack trace when a test fails'
+]
+
+Cucumber::Cli::Options::BUILTIN_FORMATS['rerundump'] = [
+  'Cucumber::Formatter::RerunDump',
+  'Outputs scenario file and line number on new lines. For use with --dry-run'
 ]
 
 Cucumber::Cli::Options::BUILTIN_FORMATS['simpledoc'] = [

--- a/spec/rerun_dump_spec.rb
+++ b/spec/rerun_dump_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Cucumber::Formatter::RerunDump do
+  it 'is a class' do
+    Cucumber::Formatter::RerunDump.is_a? Class
+  end
+end


### PR DESCRIPTION
Added a rerun dump formatter to output all scenarios with line numbers onto a new line.

output:

```
features/mixed.feature:3
features/mixed.feature:6
features/mixed.feature:9
```
